### PR TITLE
Bulk Dependabot Updates 2022/02/03

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,28 +9,28 @@
       "version": "1.0.0",
       "license": "GPL-2.0",
       "dependencies": {
-        "next": "^12.0.8",
-        "pure-react-carousel": "^1.27.8",
+        "next": "^12.0.10",
+        "pure-react-carousel": "^1.28.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
         "@arkweid/lefthook": "^0.7.7",
         "autoprefixer": "^10.4.2",
-        "eslint": "^8.7.0",
-        "eslint-config-next": "^12.0.8",
+        "eslint": "^8.8.0",
+        "eslint-config-next": "^12.0.10",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "markdownlint": "^0.25.1",
         "markdownlint-cli": "^0.30.0",
-        "postcss": "^8.4.5",
-        "postcss-preset-env": "^7.2.3",
+        "postcss": "^8.4.6",
+        "postcss-preset-env": "^7.3.1",
         "prettier": "^2.5.1",
         "prop-types": "^15.8.1",
         "rimraf": "^3.0.2",
         "stylelint": "^14.3.0",
         "stylelint-config-standard": "^24.0.0",
-        "tailwindcss": "^3.0.16"
+        "tailwindcss": "^3.0.18"
       }
     },
     "node_modules/@arkweid/lefthook": {
@@ -62,18 +62,11 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -163,20 +156,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
@@ -201,16 +180,64 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+    "node_modules/@csstools/postcss-font-format-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
+      "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
+      "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
+        "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/@csstools/postcss-hwb-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
+      "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
+    "node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.0.tgz",
+      "integrity": "sha512-WnfZlyuh/CW4oS530HBbrKq0G8BKl/bsNr5NMFoubBFzJfvFRGJhplCgIJYWUidLuL3WJ/zhMtDIyNFTqhx63Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-normalize-display-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
+      "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -254,37 +281,23 @@
       "dev": true
     },
     "node_modules/@next/env": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.8.tgz",
-      "integrity": "sha512-Wa0gOeioB9PHap9wtZDZEhgOSE3/+qE/UALWjJHuNvH4J3oE+13EjVOiEsr1JcPCXUN8ESQE+phDKlo6qJ8P9g=="
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
+      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.8.tgz",
-      "integrity": "sha512-bf7O0Mvs1h3vIdbbi0hijG+6YG3ED/ebQfmUltrQSgGtHVKGADDoE2qQhwE+mrvxuz9BD8y3mJDOSy0PBLKGBA==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.10.tgz",
+      "integrity": "sha512-PbGRnV5HGSfRGLjf8uTh1MaWgLwnjKjWiGVjK752ifITJbZ28/5AmLAFT2shDYeux8BHgpgVll5QXu7GN3YLFw==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
       }
     },
-    "node_modules/@next/react-refresh-utils": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.8.tgz",
-      "integrity": "sha512-Bq4T/aOOFQUkCF9b8k9x+HpjOevu65ZPxsYJOpgEtBuJyvb+sZREtDDLKb/RtjUeLMrWrsGD0aLteyFFtiS8Og==",
-      "peerDependencies": {
-        "react-refresh": "0.8.3",
-        "webpack": "^4 || ^5"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.8.tgz",
-      "integrity": "sha512-BiXMcOZNnXSIXv+FQvbRgbMb+iYayLX/Sb2MwR0wja+eMs46BY1x/ssXDwUBADP1M8YtrGTlSPHZqUiCU94+Mg==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
+      "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
       "cpu": [
         "arm64"
       ],
@@ -297,9 +310,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.8.tgz",
-      "integrity": "sha512-6EGMmvcIwPpwt0/iqLbXDGx6oKHAXzbowyyVXK8cqmIvhoghRFjqfiNGBs+ar6wEBGt68zhwn/77vE3iQWoFJw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
+      "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
       "cpu": [
         "arm64"
       ],
@@ -312,9 +325,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.8.tgz",
-      "integrity": "sha512-todxgQOGP/ucz5UH2kKR3XGDdkWmWr0VZAAbzgTbiFm45Ol4ih602k2nNR3xSbza9IqNhxNuUVsMpBgeo19CFQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
+      "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
       "cpu": [
         "x64"
       ],
@@ -327,9 +340,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.8.tgz",
-      "integrity": "sha512-KULmdrfI+DJxBuhEyV47MQllB/WpC3P2xbwhHezxL/LkC2nkz5SbV4k432qpx2ebjIRf9SjdQ5Oz1FjD8Urayw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
+      "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
       "cpu": [
         "arm"
       ],
@@ -342,9 +355,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.8.tgz",
-      "integrity": "sha512-1XO87wgIVPvt5fx5i8CqdhksRdcpqyzCOLW4KrE0f9pUCIT04EbsFiKdmsH9c73aqjNZMnCMXpbV+cn4hN8x1w==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
+      "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
       "cpu": [
         "arm64"
       ],
@@ -357,9 +370,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.8.tgz",
-      "integrity": "sha512-NStRZEy/rkk2G18Yhc/Jzi1Q2Dv+zH176oO8479zlDQ5syRfc6AvRHVV4iNRc8Pai58If83r/nOJkwFgGwkKLw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
+      "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
       "cpu": [
         "arm64"
       ],
@@ -372,9 +385,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.8.tgz",
-      "integrity": "sha512-rHxTGtTEDFsdT9/VjewzxE19S7W1NE+aZpm4TwbT1pSNGK9KQxQGcXjqoHMeB+VZCFknzNEoIU/vydbjZMlAuw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
+      "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
       "cpu": [
         "x64"
       ],
@@ -387,9 +400,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.8.tgz",
-      "integrity": "sha512-1F4kuFRQE10GSx7LMSvRmjMXFGpxT30g8rZzq9r/p/WKdErA4WB4uxaKEX0P8AINfuN63i4luKdR+LoacgBhYw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
+      "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
       "cpu": [
         "x64"
       ],
@@ -402,9 +415,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.8.tgz",
-      "integrity": "sha512-QuRe49jqCV61TysGopC1P0HPqFAMZMWe1nbIQLyOkDLkULmZR8N2eYZq7fwqvZE5YwhMmJA/grwWFVBqSEh5Kg==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
+      "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
       "cpu": [
         "arm64"
       ],
@@ -417,9 +430,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.8.tgz",
-      "integrity": "sha512-0RV3/julybJr1IlPCowIWrJJZyAl+sOakJEM15y1NOOsbwTQ5eKZZXSi+7e23TN4wmy5HwNvn2dKzgOEVJ+jbA==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
+      "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
       "cpu": [
         "ia32"
       ],
@@ -432,9 +445,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.8.tgz",
-      "integrity": "sha512-tTga6OFfO2JS+Yt5hdryng259c/tzNgSWkdiU2E+RBHiysAIOta57n4PJ8iPahOSqEqjaToPI76wM+o441GaNQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
+      "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
       "cpu": [
         "x64"
       ],
@@ -498,11 +511,6 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -870,14 +878,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1014,6 +1014,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/clone-regexp": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -1050,11 +1077,6 @@
       "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
       "dev": true
     },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
-    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -1069,19 +1091,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/core-js-pure": {
       "version": "3.20.2",
@@ -1161,9 +1170,9 @@
       }
     },
     "node_modules/css-prefers-color-scheme": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.2.tgz",
-      "integrity": "sha512-gv0KQBEM+q/XdoKyznovq3KW7ocO7k+FhPP+hQR1MenJdu0uPGS6IZa9PzlbqBeS6XcZJNAoqoFxlAUW461CrA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
       "dev": true,
       "bin": {
         "css-prefers-color-scheme": "dist/cli.cjs"
@@ -1172,13 +1181,13 @@
         "node": "^12 || ^14 || >=16"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/cssdb": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-5.0.0.tgz",
-      "integrity": "sha512-Q7982SynYCtcLUBCPgUPFy2TZmDiFyimpdln8K2v4w2c07W4rXL7q5F1ksVAqOAQfxKyyUGCKSsioezKT5bU1Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.1.0.tgz",
+      "integrity": "sha512-tZEDdN57Wlb5DRbOpJI9hSoP0t6DjtzSRswFoWo0hmJxfAXTBuDAcp2Oybj6BgQ+sErs9hXnWS1kzYKDKHanmg==",
       "dev": true
     },
     "node_modules/cssesc": {
@@ -1358,14 +1367,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
-    "node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -1465,9 +1466,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -1517,12 +1518,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.8.tgz",
-      "integrity": "sha512-H40jvqy/yeku3r9D556ALLaM3ZmS55hj9/MTK59fWbzsqTaYlybSkUmIBG0ZFEnBazr0NnBGwrYA5cnsFYR7RQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.10.tgz",
+      "integrity": "sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.0.8",
+        "@next/eslint-plugin-next": "12.0.10",
         "@rushstack/eslint-patch": "^1.0.8",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -2311,6 +2312,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2461,7 +2463,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -2743,33 +2746,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/jest-worker": {
-      "version": "27.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
-      "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/jkroso-type": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jkroso-type/-/jkroso-type-1.1.1.tgz",
@@ -2814,6 +2790,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -2905,19 +2882,6 @@
       "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -3165,11 +3129,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3216,7 +3175,8 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -3239,9 +3199,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3256,20 +3216,14 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.0.8.tgz",
-      "integrity": "sha512-g5c1Kuh1F8tSXJn2rVvzYBzqe9EXaR6+rY3/KrQ7y0D9FueRLfHI35wM0DRadDcPSc3+vncspfhYH3jnYE/KjA==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
+      "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
       "dependencies": {
-        "@next/env": "12.0.8",
-        "@next/react-refresh-utils": "12.0.8",
+        "@next/env": "12.0.10",
         "caniuse-lite": "^1.0.30001283",
-        "jest-worker": "27.0.0-next.5",
-        "node-fetch": "2.6.1",
-        "postcss": "8.2.15",
-        "react-is": "17.0.2",
-        "react-refresh": "0.8.3",
-        "stream-browserify": "3.0.0",
-        "styled-jsx": "5.0.0-beta.6",
+        "postcss": "8.4.5",
+        "styled-jsx": "5.0.0",
         "use-subscription": "1.5.1"
       },
       "bin": {
@@ -3279,17 +3233,17 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm64": "12.0.8",
-        "@next/swc-darwin-arm64": "12.0.8",
-        "@next/swc-darwin-x64": "12.0.8",
-        "@next/swc-linux-arm-gnueabihf": "12.0.8",
-        "@next/swc-linux-arm64-gnu": "12.0.8",
-        "@next/swc-linux-arm64-musl": "12.0.8",
-        "@next/swc-linux-x64-gnu": "12.0.8",
-        "@next/swc-linux-x64-musl": "12.0.8",
-        "@next/swc-win32-arm64-msvc": "12.0.8",
-        "@next/swc-win32-ia32-msvc": "12.0.8",
-        "@next/swc-win32-x64-msvc": "12.0.8"
+        "@next/swc-android-arm64": "12.0.10",
+        "@next/swc-darwin-arm64": "12.0.10",
+        "@next/swc-darwin-x64": "12.0.10",
+        "@next/swc-linux-arm-gnueabihf": "12.0.10",
+        "@next/swc-linux-arm64-gnu": "12.0.10",
+        "@next/swc-linux-arm64-musl": "12.0.10",
+        "@next/swc-linux-x64-gnu": "12.0.10",
+        "@next/swc-linux-x64-musl": "12.0.10",
+        "@next/swc-win32-arm64-msvc": "12.0.10",
+        "@next/swc-win32-ia32-msvc": "12.0.10",
+        "@next/swc-win32-x64-msvc": "12.0.10"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -3311,13 +3265,13 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
       "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map": "^0.6.1"
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3325,22 +3279,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/next/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -3645,8 +3583,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -3673,14 +3610,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
       "dev": true,
       "dependencies": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.2.0",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3700,6 +3637,21 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.2"
+      }
+    },
+    "node_modules/postcss-clamp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-3.0.0.tgz",
+      "integrity": "sha512-QENQMIF/Grw0qX0RzSPJjw+mAiGPIwG2AnsQDIoR/WJ5Q19zLB0NrZX8cH7CzzdDWEerTPGCdep7ItFaAdtItg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=7.6.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.5"
       }
     },
     "node_modules/postcss-color-functional-notation": {
@@ -3760,9 +3712,9 @@
       }
     },
     "node_modules/postcss-custom-properties": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.3.tgz",
-      "integrity": "sha512-rtu3otIeY532PnEuuBrIIe+N+pcdbX/7JMZfrcL09wc78YayrHw5E8UkDfvnlOhEUrI4ptCuzXQfj+Or6spbGA==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
+      "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -3771,7 +3723,7 @@
         "node": "^12 || ^14 || >=16"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-custom-selectors": {
@@ -3886,9 +3838,9 @@
       }
     },
     "node_modules/postcss-image-set-function": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.4.tgz",
-      "integrity": "sha512-BlEo9gSTj66lXjRNByvkMK9dEdEGFXRfGjKRi9fo8s0/P3oEk74cAoonl/utiM50E2OPVb/XSu+lWvdW4KtE/Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.5.tgz",
+      "integrity": "sha512-D4jXzlypkJ6BiSoUGazrRlR+GF3SED+BeiRDzOmuinDKdAn/Wuu8KtEGa5Z4pg4kxyeSMBywMgNt2+Yi/TZPPw==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -3897,7 +3849,7 @@
         "node": "^12 || ^14 || >=16"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-initial": {
@@ -4033,6 +3985,25 @@
         "postcss": "^8.3"
       }
     },
+    "node_modules/postcss-opacity-percentage": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
+      "integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "kofi",
+          "url": "https://ko-fi.com/mrcgrtz"
+        },
+        {
+          "type": "liberapay",
+          "url": "https://liberapay.com/mrcgrtz"
+        }
+      ],
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      }
+    },
     "node_modules/postcss-overflow-shorthand": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.2.tgz",
@@ -4070,24 +4041,28 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.2.3.tgz",
-      "integrity": "sha512-Ok0DhLfwrcNGrBn8sNdy1uZqWRk/9FId0GiQ39W4ILop5GHtjJs8bu1MY9isPwHInpVEPWjb4CEcEaSbBLpfwA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.3.1.tgz",
+      "integrity": "sha512-x7fNsJxfkY60P4FUNwhJUOfXBFfnObd2EcUYY97sXZ0XRLgmAE65es9EFIYHq1rAk7X3LMfbG+L9wYgkrNsq5Q==",
       "dev": true,
       "dependencies": {
+        "@csstools/postcss-font-format-keywords": "^1.0.0",
+        "@csstools/postcss-hwb-function": "^1.0.0",
+        "@csstools/postcss-is-pseudo-class": "^2.0.0",
+        "@csstools/postcss-normalize-display-values": "^1.0.0",
         "autoprefixer": "^10.4.2",
         "browserslist": "^4.19.1",
-        "caniuse-lite": "^1.0.30001299",
         "css-blank-pseudo": "^3.0.2",
         "css-has-pseudo": "^3.0.3",
-        "css-prefers-color-scheme": "^6.0.2",
-        "cssdb": "^5.0.0",
+        "css-prefers-color-scheme": "^6.0.3",
+        "cssdb": "^6.1.0",
         "postcss-attribute-case-insensitive": "^5.0.0",
+        "postcss-clamp": "^3.0.0",
         "postcss-color-functional-notation": "^4.2.1",
         "postcss-color-hex-alpha": "^8.0.2",
         "postcss-color-rebeccapurple": "^7.0.2",
         "postcss-custom-media": "^8.0.0",
-        "postcss-custom-properties": "^12.1.2",
+        "postcss-custom-properties": "^12.1.4",
         "postcss-custom-selectors": "^6.0.0",
         "postcss-dir-pseudo-class": "^6.0.3",
         "postcss-double-position-gradients": "^3.0.4",
@@ -4096,16 +4071,17 @@
         "postcss-focus-within": "^5.0.3",
         "postcss-font-variant": "^5.0.0",
         "postcss-gap-properties": "^3.0.2",
-        "postcss-image-set-function": "^4.0.4",
+        "postcss-image-set-function": "^4.0.5",
         "postcss-initial": "^4.0.1",
         "postcss-lab-function": "^4.0.3",
         "postcss-logical": "^5.0.3",
         "postcss-media-minmax": "^5.0.0",
         "postcss-nesting": "^10.1.2",
+        "postcss-opacity-percentage": "^1.1.2",
         "postcss-overflow-shorthand": "^3.0.2",
         "postcss-page-break": "^3.0.4",
         "postcss-place": "^7.0.3",
-        "postcss-pseudo-class-any-link": "^7.0.2",
+        "postcss-pseudo-class-any-link": "^7.1.0",
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0"
       },
@@ -4117,18 +4093,18 @@
       }
     },
     "node_modules/postcss-pseudo-class-any-link": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.0.2.tgz",
-      "integrity": "sha512-CG35J1COUH7OOBgpw5O+0koOLUd5N4vUGKUqSAuIe4GiuLHWU96Pqp+UPC8QITTd12zYAFx76pV7qWT/0Aj/TA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.0.tgz",
+      "integrity": "sha512-l7sAkLmm3bYq8wt8/0r/dn6o9mVCPq7MOiNrb/Xi2zBlw/+w1V2jKFo/3IijKHfJ92SwDqkVLPwQfGO3xxUdAw==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.8"
+        "postcss-selector-parser": "^6.0.9"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-replace-overflow-wrap": {
@@ -4251,9 +4227,9 @@
       }
     },
     "node_modules/pure-react-carousel": {
-      "version": "1.27.8",
-      "resolved": "https://registry.npmjs.org/pure-react-carousel/-/pure-react-carousel-1.27.8.tgz",
-      "integrity": "sha512-QRx45OIKw4MqjVcacjkTo8JZYsdNLL/iXJYy+t5bZCz+q3i3vuD3P+Cg/44NdgKrKU/HKgN0ccZKlOqum+neaw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/pure-react-carousel/-/pure-react-carousel-1.28.0.tgz",
+      "integrity": "sha512-v+m842G9nOahLuaS0IVN8rTpUKKukxELqPYUiQck/IFnUi4IOPrdBvw9lhtAvMh0MlTiuBlcru/DyPewEQDC2Q==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "deep-freeze": "0.0.1",
@@ -4318,19 +4294,6 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-refresh": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
-      "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read-pkg": {
@@ -4471,17 +4434,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/readable-stream": {
+    "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "picomatch": "^2.2.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=8.10.0"
       }
     },
     "node_modules/redent": {
@@ -4628,25 +4590,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -4738,19 +4681,10 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4795,28 +4729,6 @@
       "bin": {
         "specificity": "bin/specificity"
       }
-    },
-    "node_modules/stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "dependencies": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4935,19 +4847,9 @@
       "dev": true
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.6.tgz",
-      "integrity": "sha512-b1cM7Xyp2r1lsNpvoZ6wmTI8qxD0557vH2feHakNU8LMkzfJDgTQMul6O7sSYY0GxQ73pKEN69hCDp71w6Q0nA==",
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": "7.14.5",
-        "@babel/types": "7.15.0",
-        "convert-source-map": "1.7.0",
-        "loader-utils": "1.2.3",
-        "source-map": "0.7.3",
-        "string-hash": "1.1.3",
-        "stylis": "3.5.4",
-        "stylis-rule-sheet": "0.0.10"
-      },
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
+      "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4956,6 +4858,9 @@
       },
       "peerDependenciesMeta": {
         "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
           "optional": true
         }
       }
@@ -5063,19 +4968,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-    },
-    "node_modules/stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "peerDependencies": {
-        "stylis": "^3.5.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5158,14 +5050,14 @@
       "dev": true
     },
     "node_modules/tailwindcss": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.16.tgz",
-      "integrity": "sha512-1L8E5Wr+o1c4kxxObNz2owJe94a7BLEMV+2Lz6wzprJdcs3ENSRR9t4OZf2OqtRNS/q/zFPuOKoLtQoy3Lrhhw==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.18.tgz",
+      "integrity": "sha512-ihPTpEyA5ANgZbwKlgrbfnzOp9R5vDHFWmqxB1PT8NwOGCOFVVMl+Ps1cQQ369acaqqf1BEF77roCwK0lvNmTw==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.1",
         "chalk": "^4.1.2",
-        "chokidar": "^3.5.2",
+        "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
         "cosmiconfig": "^7.0.1",
         "detective": "^5.2.0",
@@ -5179,7 +5071,7 @@
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.0",
         "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.8",
+        "postcss-selector-parser": "^6.0.9",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.21.0"
@@ -5194,39 +5086,6 @@
       "peerDependencies": {
         "autoprefixer": "^10.0.2",
         "postcss": "^8.0.9"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "dev": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {
@@ -5253,31 +5112,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tailwindcss/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5421,7 +5260,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -5550,15 +5390,11 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "@babel/helper-plugin-utils": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "dev": true
     },
     "@babel/highlight": {
       "version": "7.14.5",
@@ -5629,14 +5465,6 @@
         }
       }
     },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
     "@babel/runtime": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
@@ -5655,13 +5483,40 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+    "@csstools/postcss-font-format-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
+      "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
+      "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "@csstools/postcss-hwb-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
+      "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "@csstools/postcss-is-pseudo-class": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.0.tgz",
+      "integrity": "sha512-WnfZlyuh/CW4oS530HBbrKq0G8BKl/bsNr5NMFoubBFzJfvFRGJhplCgIJYWUidLuL3WJ/zhMtDIyNFTqhx63Q==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.9"
+      }
+    },
+    "@csstools/postcss-normalize-display-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
+      "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.2.0"
       }
     },
     "@eslint/eslintrc": {
@@ -5699,88 +5554,83 @@
       "dev": true
     },
     "@next/env": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.8.tgz",
-      "integrity": "sha512-Wa0gOeioB9PHap9wtZDZEhgOSE3/+qE/UALWjJHuNvH4J3oE+13EjVOiEsr1JcPCXUN8ESQE+phDKlo6qJ8P9g=="
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
+      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.8.tgz",
-      "integrity": "sha512-bf7O0Mvs1h3vIdbbi0hijG+6YG3ED/ebQfmUltrQSgGtHVKGADDoE2qQhwE+mrvxuz9BD8y3mJDOSy0PBLKGBA==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.10.tgz",
+      "integrity": "sha512-PbGRnV5HGSfRGLjf8uTh1MaWgLwnjKjWiGVjK752ifITJbZ28/5AmLAFT2shDYeux8BHgpgVll5QXu7GN3YLFw==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
       }
     },
-    "@next/react-refresh-utils": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.8.tgz",
-      "integrity": "sha512-Bq4T/aOOFQUkCF9b8k9x+HpjOevu65ZPxsYJOpgEtBuJyvb+sZREtDDLKb/RtjUeLMrWrsGD0aLteyFFtiS8Og=="
-    },
     "@next/swc-android-arm64": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.8.tgz",
-      "integrity": "sha512-BiXMcOZNnXSIXv+FQvbRgbMb+iYayLX/Sb2MwR0wja+eMs46BY1x/ssXDwUBADP1M8YtrGTlSPHZqUiCU94+Mg==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
+      "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.8.tgz",
-      "integrity": "sha512-6EGMmvcIwPpwt0/iqLbXDGx6oKHAXzbowyyVXK8cqmIvhoghRFjqfiNGBs+ar6wEBGt68zhwn/77vE3iQWoFJw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
+      "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.8.tgz",
-      "integrity": "sha512-todxgQOGP/ucz5UH2kKR3XGDdkWmWr0VZAAbzgTbiFm45Ol4ih602k2nNR3xSbza9IqNhxNuUVsMpBgeo19CFQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
+      "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.8.tgz",
-      "integrity": "sha512-KULmdrfI+DJxBuhEyV47MQllB/WpC3P2xbwhHezxL/LkC2nkz5SbV4k432qpx2ebjIRf9SjdQ5Oz1FjD8Urayw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
+      "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.8.tgz",
-      "integrity": "sha512-1XO87wgIVPvt5fx5i8CqdhksRdcpqyzCOLW4KrE0f9pUCIT04EbsFiKdmsH9c73aqjNZMnCMXpbV+cn4hN8x1w==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
+      "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.8.tgz",
-      "integrity": "sha512-NStRZEy/rkk2G18Yhc/Jzi1Q2Dv+zH176oO8479zlDQ5syRfc6AvRHVV4iNRc8Pai58If83r/nOJkwFgGwkKLw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
+      "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.8.tgz",
-      "integrity": "sha512-rHxTGtTEDFsdT9/VjewzxE19S7W1NE+aZpm4TwbT1pSNGK9KQxQGcXjqoHMeB+VZCFknzNEoIU/vydbjZMlAuw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
+      "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.8.tgz",
-      "integrity": "sha512-1F4kuFRQE10GSx7LMSvRmjMXFGpxT30g8rZzq9r/p/WKdErA4WB4uxaKEX0P8AINfuN63i4luKdR+LoacgBhYw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
+      "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.8.tgz",
-      "integrity": "sha512-QuRe49jqCV61TysGopC1P0HPqFAMZMWe1nbIQLyOkDLkULmZR8N2eYZq7fwqvZE5YwhMmJA/grwWFVBqSEh5Kg==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
+      "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.8.tgz",
-      "integrity": "sha512-0RV3/julybJr1IlPCowIWrJJZyAl+sOakJEM15y1NOOsbwTQ5eKZZXSi+7e23TN4wmy5HwNvn2dKzgOEVJ+jbA==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
+      "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.8.tgz",
-      "integrity": "sha512-tTga6OFfO2JS+Yt5hdryng259c/tzNgSWkdiU2E+RBHiysAIOta57n4PJ8iPahOSqEqjaToPI76wM+o441GaNQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
+      "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -5826,11 +5676,6 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
-    },
-    "@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6076,11 +5921,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6173,6 +6013,22 @@
         "supports-color": "^7.1.0"
       }
     },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
     "clone-regexp": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -6203,11 +6059,6 @@
       "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
       "dev": true
     },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
-    },
     "commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -6219,21 +6070,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
     },
     "core-js-pure": {
       "version": "3.20.2",
@@ -6284,15 +6120,15 @@
       }
     },
     "css-prefers-color-scheme": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.2.tgz",
-      "integrity": "sha512-gv0KQBEM+q/XdoKyznovq3KW7ocO7k+FhPP+hQR1MenJdu0uPGS6IZa9PzlbqBeS6XcZJNAoqoFxlAUW461CrA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
       "dev": true
     },
     "cssdb": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-5.0.0.tgz",
-      "integrity": "sha512-Q7982SynYCtcLUBCPgUPFy2TZmDiFyimpdln8K2v4w2c07W4rXL7q5F1ksVAqOAQfxKyyUGCKSsioezKT5bU1Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.1.0.tgz",
+      "integrity": "sha512-tZEDdN57Wlb5DRbOpJI9hSoP0t6DjtzSRswFoWo0hmJxfAXTBuDAcp2Oybj6BgQ+sErs9hXnWS1kzYKDKHanmg==",
       "dev": true
     },
     "cssesc": {
@@ -6430,11 +6266,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
     "entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -6510,9 +6341,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",
@@ -6570,12 +6401,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.8.tgz",
-      "integrity": "sha512-H40jvqy/yeku3r9D556ALLaM3ZmS55hj9/MTK59fWbzsqTaYlybSkUmIBG0ZFEnBazr0NnBGwrYA5cnsFYR7RQ==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.10.tgz",
+      "integrity": "sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.0.8",
+        "@next/eslint-plugin-next": "12.0.10",
         "@rushstack/eslint-patch": "^1.0.8",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -7155,7 +6986,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -7260,7 +7092,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "2.0.0",
@@ -7452,26 +7285,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jest-worker": {
-      "version": "27.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
-      "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
-      "requires": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jkroso-type": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jkroso-type/-/jkroso-type-1.1.1.tgz",
@@ -7513,6 +7326,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -7589,16 +7403,6 @@
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
-      }
-    },
-    "loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
       }
     },
     "locate-path": {
@@ -7792,11 +7596,6 @@
         }
       }
     },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7831,7 +7630,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -7851,9 +7651,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -7862,55 +7662,39 @@
       "dev": true
     },
     "next": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.0.8.tgz",
-      "integrity": "sha512-g5c1Kuh1F8tSXJn2rVvzYBzqe9EXaR6+rY3/KrQ7y0D9FueRLfHI35wM0DRadDcPSc3+vncspfhYH3jnYE/KjA==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
+      "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
       "requires": {
-        "@next/env": "12.0.8",
-        "@next/react-refresh-utils": "12.0.8",
-        "@next/swc-android-arm64": "12.0.8",
-        "@next/swc-darwin-arm64": "12.0.8",
-        "@next/swc-darwin-x64": "12.0.8",
-        "@next/swc-linux-arm-gnueabihf": "12.0.8",
-        "@next/swc-linux-arm64-gnu": "12.0.8",
-        "@next/swc-linux-arm64-musl": "12.0.8",
-        "@next/swc-linux-x64-gnu": "12.0.8",
-        "@next/swc-linux-x64-musl": "12.0.8",
-        "@next/swc-win32-arm64-msvc": "12.0.8",
-        "@next/swc-win32-ia32-msvc": "12.0.8",
-        "@next/swc-win32-x64-msvc": "12.0.8",
+        "@next/env": "12.0.10",
+        "@next/swc-android-arm64": "12.0.10",
+        "@next/swc-darwin-arm64": "12.0.10",
+        "@next/swc-darwin-x64": "12.0.10",
+        "@next/swc-linux-arm-gnueabihf": "12.0.10",
+        "@next/swc-linux-arm64-gnu": "12.0.10",
+        "@next/swc-linux-arm64-musl": "12.0.10",
+        "@next/swc-linux-x64-gnu": "12.0.10",
+        "@next/swc-linux-x64-musl": "12.0.10",
+        "@next/swc-win32-arm64-msvc": "12.0.10",
+        "@next/swc-win32-ia32-msvc": "12.0.10",
+        "@next/swc-win32-x64-msvc": "12.0.10",
         "caniuse-lite": "^1.0.30001283",
-        "jest-worker": "27.0.0-next.5",
-        "node-fetch": "2.6.1",
-        "postcss": "8.2.15",
-        "react-is": "17.0.2",
-        "react-refresh": "0.8.3",
-        "stream-browserify": "3.0.0",
-        "styled-jsx": "5.0.0-beta.6",
+        "postcss": "8.4.5",
+        "styled-jsx": "5.0.0",
         "use-subscription": "1.5.1"
       },
       "dependencies": {
         "postcss": {
-          "version": "8.2.15",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-          "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+          "version": "8.4.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
           "requires": {
-            "colorette": "^1.2.2",
-            "nanoid": "^3.1.23",
-            "source-map": "^0.6.1"
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.1"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-releases": {
       "version": "2.0.1",
@@ -8135,8 +7919,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -8154,14 +7937,14 @@
       }
     },
     "postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.2.0",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-attribute-case-insensitive": {
@@ -8171,6 +7954,15 @@
       "dev": true,
       "requires": {
         "postcss-selector-parser": "^6.0.2"
+      }
+    },
+    "postcss-clamp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-3.0.0.tgz",
+      "integrity": "sha512-QENQMIF/Grw0qX0RzSPJjw+mAiGPIwG2AnsQDIoR/WJ5Q19zLB0NrZX8cH7CzzdDWEerTPGCdep7ItFaAdtItg==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "postcss-color-functional-notation": {
@@ -8207,9 +7999,9 @@
       "dev": true
     },
     "postcss-custom-properties": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.3.tgz",
-      "integrity": "sha512-rtu3otIeY532PnEuuBrIIe+N+pcdbX/7JMZfrcL09wc78YayrHw5E8UkDfvnlOhEUrI4ptCuzXQfj+Or6spbGA==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
+      "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
@@ -8282,9 +8074,9 @@
       "dev": true
     },
     "postcss-image-set-function": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.4.tgz",
-      "integrity": "sha512-BlEo9gSTj66lXjRNByvkMK9dEdEGFXRfGjKRi9fo8s0/P3oEk74cAoonl/utiM50E2OPVb/XSu+lWvdW4KtE/Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.5.tgz",
+      "integrity": "sha512-D4jXzlypkJ6BiSoUGazrRlR+GF3SED+BeiRDzOmuinDKdAn/Wuu8KtEGa5Z4pg4kxyeSMBywMgNt2+Yi/TZPPw==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
@@ -8361,6 +8153,12 @@
         "postcss-selector-parser": "^6.0.8"
       }
     },
+    "postcss-opacity-percentage": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
+      "integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w==",
+      "dev": true
+    },
     "postcss-overflow-shorthand": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.2.tgz",
@@ -8383,24 +8181,28 @@
       }
     },
     "postcss-preset-env": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.2.3.tgz",
-      "integrity": "sha512-Ok0DhLfwrcNGrBn8sNdy1uZqWRk/9FId0GiQ39W4ILop5GHtjJs8bu1MY9isPwHInpVEPWjb4CEcEaSbBLpfwA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.3.1.tgz",
+      "integrity": "sha512-x7fNsJxfkY60P4FUNwhJUOfXBFfnObd2EcUYY97sXZ0XRLgmAE65es9EFIYHq1rAk7X3LMfbG+L9wYgkrNsq5Q==",
       "dev": true,
       "requires": {
+        "@csstools/postcss-font-format-keywords": "^1.0.0",
+        "@csstools/postcss-hwb-function": "^1.0.0",
+        "@csstools/postcss-is-pseudo-class": "^2.0.0",
+        "@csstools/postcss-normalize-display-values": "^1.0.0",
         "autoprefixer": "^10.4.2",
         "browserslist": "^4.19.1",
-        "caniuse-lite": "^1.0.30001299",
         "css-blank-pseudo": "^3.0.2",
         "css-has-pseudo": "^3.0.3",
-        "css-prefers-color-scheme": "^6.0.2",
-        "cssdb": "^5.0.0",
+        "css-prefers-color-scheme": "^6.0.3",
+        "cssdb": "^6.1.0",
         "postcss-attribute-case-insensitive": "^5.0.0",
+        "postcss-clamp": "^3.0.0",
         "postcss-color-functional-notation": "^4.2.1",
         "postcss-color-hex-alpha": "^8.0.2",
         "postcss-color-rebeccapurple": "^7.0.2",
         "postcss-custom-media": "^8.0.0",
-        "postcss-custom-properties": "^12.1.2",
+        "postcss-custom-properties": "^12.1.4",
         "postcss-custom-selectors": "^6.0.0",
         "postcss-dir-pseudo-class": "^6.0.3",
         "postcss-double-position-gradients": "^3.0.4",
@@ -8409,27 +8211,28 @@
         "postcss-focus-within": "^5.0.3",
         "postcss-font-variant": "^5.0.0",
         "postcss-gap-properties": "^3.0.2",
-        "postcss-image-set-function": "^4.0.4",
+        "postcss-image-set-function": "^4.0.5",
         "postcss-initial": "^4.0.1",
         "postcss-lab-function": "^4.0.3",
         "postcss-logical": "^5.0.3",
         "postcss-media-minmax": "^5.0.0",
         "postcss-nesting": "^10.1.2",
+        "postcss-opacity-percentage": "^1.1.2",
         "postcss-overflow-shorthand": "^3.0.2",
         "postcss-page-break": "^3.0.4",
         "postcss-place": "^7.0.3",
-        "postcss-pseudo-class-any-link": "^7.0.2",
+        "postcss-pseudo-class-any-link": "^7.1.0",
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0"
       }
     },
     "postcss-pseudo-class-any-link": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.0.2.tgz",
-      "integrity": "sha512-CG35J1COUH7OOBgpw5O+0koOLUd5N4vUGKUqSAuIe4GiuLHWU96Pqp+UPC8QITTd12zYAFx76pV7qWT/0Aj/TA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.0.tgz",
+      "integrity": "sha512-l7sAkLmm3bYq8wt8/0r/dn6o9mVCPq7MOiNrb/Xi2zBlw/+w1V2jKFo/3IijKHfJ92SwDqkVLPwQfGO3xxUdAw==",
       "dev": true,
       "requires": {
-        "postcss-selector-parser": "^6.0.8"
+        "postcss-selector-parser": "^6.0.9"
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -8520,9 +8323,9 @@
       "dev": true
     },
     "pure-react-carousel": {
-      "version": "1.27.8",
-      "resolved": "https://registry.npmjs.org/pure-react-carousel/-/pure-react-carousel-1.27.8.tgz",
-      "integrity": "sha512-QRx45OIKw4MqjVcacjkTo8JZYsdNLL/iXJYy+t5bZCz+q3i3vuD3P+Cg/44NdgKrKU/HKgN0ccZKlOqum+neaw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/pure-react-carousel/-/pure-react-carousel-1.28.0.tgz",
+      "integrity": "sha512-v+m842G9nOahLuaS0IVN8rTpUKKukxELqPYUiQck/IFnUi4IOPrdBvw9lhtAvMh0MlTiuBlcru/DyPewEQDC2Q==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "deep-freeze": "0.0.1",
@@ -8561,16 +8364,6 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
-    },
-    "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-refresh": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
-      "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -8678,14 +8471,13 @@
         }
       }
     },
-    "readable-stream": {
+    "readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "picomatch": "^2.2.1"
       }
     },
     "redent": {
@@ -8778,11 +8570,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
     "scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -8850,16 +8637,10 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
-    "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-    },
     "source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -8898,28 +8679,6 @@
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
-    },
-    "stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "requires": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-width": {
       "version": "4.2.3",
@@ -9013,19 +8772,9 @@
       "dev": true
     },
     "styled-jsx": {
-      "version": "5.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.6.tgz",
-      "integrity": "sha512-b1cM7Xyp2r1lsNpvoZ6wmTI8qxD0557vH2feHakNU8LMkzfJDgTQMul6O7sSYY0GxQ73pKEN69hCDp71w6Q0nA==",
-      "requires": {
-        "@babel/plugin-syntax-jsx": "7.14.5",
-        "@babel/types": "7.15.0",
-        "convert-source-map": "1.7.0",
-        "loader-utils": "1.2.3",
-        "source-map": "0.7.3",
-        "string-hash": "1.1.3",
-        "stylis": "3.5.4",
-        "stylis-rule-sheet": "0.0.10"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
+      "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA=="
     },
     "stylelint": {
       "version": "14.3.0",
@@ -9110,16 +8859,6 @@
         "stylelint-config-recommended": "^6.0.0"
       }
     },
-    "stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9185,14 +8924,14 @@
       }
     },
     "tailwindcss": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.16.tgz",
-      "integrity": "sha512-1L8E5Wr+o1c4kxxObNz2owJe94a7BLEMV+2Lz6wzprJdcs3ENSRR9t4OZf2OqtRNS/q/zFPuOKoLtQoy3Lrhhw==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.18.tgz",
+      "integrity": "sha512-ihPTpEyA5ANgZbwKlgrbfnzOp9R5vDHFWmqxB1PT8NwOGCOFVVMl+Ps1cQQ369acaqqf1BEF77roCwK0lvNmTw==",
       "dev": true,
       "requires": {
         "arg": "^5.0.1",
         "chalk": "^4.1.2",
-        "chokidar": "^3.5.2",
+        "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
         "cosmiconfig": "^7.0.1",
         "detective": "^5.2.0",
@@ -9206,39 +8945,12 @@
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.0",
         "postcss-nested": "5.0.6",
-        "postcss-selector-parser": "^6.0.8",
+        "postcss-selector-parser": "^6.0.9",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
         "resolve": "^1.21.0"
       },
       "dependencies": {
-        "chokidar": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          },
-          "dependencies": {
-            "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-              "dev": true,
-              "requires": {
-                "is-glob": "^4.0.1"
-              }
-            }
-          }
-        },
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -9253,15 +8965,6 @@
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
           "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
           "dev": true
-        },
-        "readdirp": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
         }
       }
     },
@@ -9270,11 +8973,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -9377,7 +9075,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,27 +27,27 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^12.0.8",
-    "pure-react-carousel": "^1.27.8",
+    "next": "^12.0.10",
+    "pure-react-carousel": "^1.28.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.7",
     "autoprefixer": "^10.4.2",
-    "eslint": "^8.7.0",
-    "eslint-config-next": "^12.0.8",
+    "eslint": "^8.8.0",
+    "eslint-config-next": "^12.0.10",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "markdownlint": "^0.25.1",
     "markdownlint-cli": "^0.30.0",
-    "postcss": "^8.4.5",
-    "postcss-preset-env": "^7.2.3",
+    "postcss": "^8.4.6",
+    "postcss-preset-env": "^7.3.1",
     "prettier": "^2.5.1",
     "prop-types": "^15.8.1",
     "rimraf": "^3.0.2",
     "stylelint": "^14.3.0",
     "stylelint-config-standard": "^24.0.0",
-    "tailwindcss": "^3.0.16"
+    "tailwindcss": "^3.0.18"
   }
 }


### PR DESCRIPTION
### Link
https://legend-of-the-headless-website-git-feature-b7a074-webdevstudios.vercel.app/

### Description

This PR updates the following Node modules:

- Bulk Dependabot Updates
    ```bash
     next                 ^12.0.8  →  ^12.0.10
     pure-react-carousel  ^1.27.8  →   ^1.28.0
     eslint                ^8.7.0  →    ^8.8.0
     eslint-config-next   ^12.0.8  →  ^12.0.10
     postcss               ^8.4.5  →    ^8.4.6
     postcss-preset-env    ^7.2.3  →    ^7.3.1
     tailwindcss          ^3.0.16  →   ^3.0.18
    ```
### Screenshot
Frontend
![screenshot](https://user-images.githubusercontent.com/43300142/152379900-5bcefb0e-af6f-4af0-8496-ddaedc309343.png)

Build
![screenshot](https://user-images.githubusercontent.com/43300142/152379934-6987b017-0a4d-446d-8e34-a3d8e33b330e.png)

Format
![screenshot](https://user-images.githubusercontent.com/43300142/152379987-40948c73-c332-4257-9b7d-fa35e8dcc10b.png)

Lint
![screenshot](https://user-images.githubusercontent.com/43300142/152380215-4866d271-98ac-4689-8fe1-d047b2975c44.png)

### Verification

1. `gh pr checkout 1`
2. `npm ci`
3. `npm run build && npm start`
4. `npm run format`
5. `npm run lint`
